### PR TITLE
Fixes #26 - adds MIDI sustain.

### DIFF
--- a/src/com/gallantrealm/modsynth/module/Keyboard.java
+++ b/src/com/gallantrealm/modsynth/module/Keyboard.java
@@ -21,6 +21,7 @@ public class Keyboard extends Module {
 	public CC voicesCC;
 	public CC tuningCC;
 	public CC octaveCC;
+	public CC sustainCC;
 
 //	private transient float[] prepreLevel;
 	private transient float[] preLevel;
@@ -331,6 +332,11 @@ public class Keyboard extends Module {
 			octaveCC = new CC();
 			octaveCC.setRangeLimits(0, 9);
 		}
+		if (sustainCC == null) {
+			sustainCC = new CC();
+			sustainCC.setRangeLimits(0, 1);
+			sustainCC.cc = 64; //Use default sustain CC
+		}
 		noteVelocities = new float[256];
 		
 		  // replaced legato with zero voices
@@ -396,6 +402,9 @@ public class Keyboard extends Module {
 		if (octaveCC.cc == cc) {
 			double v = octaveCC.range(value);
 			octave = (int)v;
+		}
+		if (sustainCC.cc == cc) {
+			setSustaining(value > 0.5);
 		}
 	}
 

--- a/src/com/gallantrealm/modsynth/viewer/KeyboardViewer.java
+++ b/src/com/gallantrealm/modsynth/viewer/KeyboardViewer.java
@@ -129,6 +129,7 @@ public class KeyboardViewer extends ModuleViewer {
 				mainActivity.updateKeysPressed();
 			}
 		});
+		sustainBox.setOnLongClickListener(MidiControlDialog.newLongClickListener(module.sustainCC));
 
 		module.dirty = false;
 	}
@@ -165,6 +166,15 @@ public class KeyboardViewer extends ModuleViewer {
 				public void run() {
 					final Spinner tuningSpinner = (Spinner) view.findViewById(R.id.keyboardTuningSpinner);
 					tuningSpinner.setSelection(module.tuning);
+				}
+			});
+		}
+		if (module.sustainCC.cc == cc) {
+			view.post(new Runnable() {
+				@Override
+				public void run() {
+					final CheckBox sustainCheckBox = (CheckBox) view.findViewById(R.id.keyboardSustain);
+					sustainCheckBox.setChecked(module.getSustaining());
 				}
 			});
 		}


### PR DESCRIPTION
This PR adds MIDI controller to the keyboard sustain parameter and sets its default controller to 64 (sustain pedal).
Note: It does not call sustainCC.range because this is a Boolean parameter so avoids overhead of getting range.